### PR TITLE
Remove undeclared variable

### DIFF
--- a/mqtt/init.lua
+++ b/mqtt/init.lua
@@ -107,7 +107,7 @@ mqtt_mt = {
       local mq = self.mqtt
       while true do
         fiber.testcancel()
-        self.connected, _ = mq:io_run_one()
+        self.connected = mq:io_run_one()
         if not self.connected then
           if self.auto_reconect then
             self:__reconnect()


### PR DESCRIPTION
This breaks event loop:
`main C> entering the event loop `
`main/108/lua utils.c:923 E> LuajitError: /opt/tarantool/.rocks/share/tarantool/mqtt/init.lua:110: assign to undeclared variable '_'   `