### PR TITLE
Remove reinitialise() from the public API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ Lua API documentation.
 
 Note that a client will never discard its own outgoing messages on disconnect. 
 Calling [connect](#connect) or [reconnect](#reconnect) will resend the messages.
-Use the `reinitialise` function to reset the client to its original state.
 
   Returns:
 

--- a/mqtt/init.lua
+++ b/mqtt/init.lua
@@ -48,8 +48,6 @@ local mqtt_mt
 --                   Note that a client will never discard its own outgoing
 --                   messages on disconnect. Calling <connect> or
 --                   <reconnect> will cause the messages to be resent.
---                   Use <reinitialise> to reset a client to its
---                   original state.
 --                   Must be set to true if the id parameter is NULL.
 --
 --  Returns:


### PR DESCRIPTION
It was removed a long time ago as Vasiliy Soshnikov says.