### PR TITLE
#39: Do not try to install mosquitto binary in /sbin on MacOS

### DIFF
--- a/mqtt/CMakeLists.txt
+++ b/mqtt/CMakeLists.txt
@@ -20,6 +20,10 @@ add_library(driver SHARED driver.c)
 
 if( DEFINED STATIC_BUILD )
 	set(CMAKE_C_FLAGS "-ldl -lpthread")
+	if (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+		# mosquitto wants to install binaries into /usr/local/sbin
+		set(CMAKE_INSTALL_SBINDIR ${CMAKE_INSTALL_BINDIR})
+	endif()
 	add_subdirectory(../third_party/mosquitto ../third_party/mosquitto/build)
 	include_directories(../third_party/mosquitto/lib)
 	if( STATIC_BUILD )


### PR DESCRIPTION
Fixes #39 
Tested on my mac:
```
a.kuzin@a:~/sources/tarantool/mqtt$ ls -l /usr/local/sbin
a.kuzin@a:~/sources/tarantool/mqtt$ ls -l /usr/local/bin | grep mosq
-rwxr-xr-x   1 a.kuzin  admin  261972 27 апр 10:55 mosquitto
-rwxr-xr-x   1 a.kuzin  admin   29660 27 апр 10:55 mosquitto_passwd
-rwxr-xr-x   1 a.kuzin  admin   59392 27 апр 10:55 mosquitto_pub
-rwxr-xr-x   1 a.kuzin  admin   59768 27 апр 10:55 mosquitto_rr
-rwxr-xr-x   1 a.kuzin  admin   59040 27 апр 10:55 mosquitto_sub
```