### PR TITLE
rocks: unable to install with tarantoolctl rocks on Linux

### DIFF
--- a/mqtt-scm-1.rockspec
+++ b/mqtt-scm-1.rockspec
@@ -18,7 +18,7 @@ build = {
         CMAKE_BUILD_TYPE="RelWithDebInfo";
         TARANTOOL_INSTALL_LIBDIR="$(LIBDIR)";
         TARANTOOL_INSTALL_LUADIR="$(LUADIR)";
-        STATIC_BUILD="$(STATIC_BUILD)";
+        STATIC_BUILD="ON";
     };
     platforms = {
         macosx = {

--- a/mqtt/CMakeLists.txt
+++ b/mqtt/CMakeLists.txt
@@ -4,6 +4,7 @@
 option(DOCUMENTATION "Build documentation?" OFF)
 
 option(WITH_STATIC_LIBRARIES "Build static versions of the libmosquitto/pp libraries?" OFF)
+option(WITH_PIC "Build the static library with PIC (Position Independent Code) enabled archives?" OFF)
 
 if( STATIC_BUILD )
 	set(WITH_STATIC_LIBRARIES ON)
@@ -20,7 +21,7 @@ add_library(driver SHARED driver.c)
 
 if( DEFINED STATIC_BUILD )
 	set(CMAKE_C_FLAGS "-ldl -lpthread")
-	add_subdirectory(../third_party/mosquitto ../third_party/mosquitto/build)
+	add_subdirectory(../third_party/mosquitto ../third_party/mosquitto/build EXCLUDE_FROM_ALL)
 	include_directories(../third_party/mosquitto/lib)
 	if( STATIC_BUILD )
 		target_link_libraries(driver libmosquitto_static ${LDFLAGS_EX})


### PR DESCRIPTION
The problem from #39 is solved by adding EXCLUDE_FROM_ALL option.

On any platforms many targets from subdirectories are included into make command by default. They are not necessary to build driver.{so|dylib}. EXCLUDE_FROM_ALL option disables all targets at the beginning and only targets which are explicitly added to mqtt dependencies will be built.

Additionally static build for rocks set by default.

Fixes #39